### PR TITLE
Add badges to README.md for crates.io and docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 **A flexible and easy-to-use logger that writes logs to stderr and/or to files,
 and that can be influenced while the program is running.**
 
+[![Latest version](https://img.shields.io/crates/v/flexi_logger.svg)](https://crates.io/crates/flexi_logger)
+[![Documentation](https://docs.rs/flexi_logger/badge.svg)](https://docs.rs/flexi_logger)
+![License](https://img.shields.io/crates/l/flexi_logger.svg)
+
 ## Usage
 
 Add flexi_logger to the dependencies section in your project's `Cargo.toml`, with


### PR DESCRIPTION
Hi emabee,
finding flexi_logger on GitHub, it was quite annoying to open up a new tab with [crates.io](https://crates.io/) and search there for flexi_logger again. Same with [docs.rs](https://docs.rs/).

So I added badges with links to those sites. 

Moreover there is now also a badge for the license since this wasn’t mentioned anywhere on GitHub but on [crates.io](https://crates.io/).

Tell me if you need any other changes and thank you for this crate 😄, 

flofriday